### PR TITLE
feat: github packages android distribution

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -1,0 +1,45 @@
+# This workflow will build a package using Gradle and then publish it to GitHub packages when a release is created
+# For more info see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#Publishing-using-gradle
+
+name: Gradle Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+        settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
+
+    - name: Extract version from tag
+      id: version
+      run: echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+
+    - name: Build with Gradle
+      working-directory: bindings/android
+      run: ./gradlew build -Pversion=${{ steps.version.outputs.version }}
+
+    # same credentials env vars used in the publishing section of build.gradle.kts
+    - name: Publish to GitHub Packages
+      working-directory: bindings/android
+      env:
+        GITHUB_ACTOR: ${{ github.actor }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_REPO: ${{ github.repository }}
+      run: ./gradlew publish -Pversion=${{ steps.version.outputs.version }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 .idea/
+.DS_Store

--- a/bindings/android/.gitignore
+++ b/bindings/android/.gitignore
@@ -1,5 +1,3 @@
 .gradle
-.idea
-.DS_Store
 build
 local.properties

--- a/bindings/android/README.md
+++ b/bindings/android/README.md
@@ -4,23 +4,88 @@ Android library for Bitkit Core bindings.
 
 ## Installation
 
-### Via JitPack (Recommended)
+### GitHub Packages
 
-See [Jitpack.io](https://jitpack.io/).
+#### 1. Setup your GitHub credentials
 
-### Via Maven Local (Development)
+Create a GitHub PAT (Personal Access Token):
+- Go to GitHub → Settings → Developer settings → Personal access tokens → Tokens (classic)
+- Generate new token with scopes: `read:packages` (and `repo` if package/repo is private)
+- Copy the token once and use it in the next steps:
+
+Set env vars:
+```sh
+export GITHUB_ACTOR="your_pat_with_read"
+export GITHUB_TOKEN="your_pat_with_read:packages"
+```
+
+Or add to `~/.gradle/gradle.properties`:
+```properties
+# ~/.gradle/gradle.properties
+gpr.user=<your_github_username>
+gpr.key=<your_pat_with_read:packages>
+```
+
+#### 2. Add the GitHub Packages repository
 
 ```kotlin
 // settings.gradle.kts
 dependencyResolutionManagement {
-    repositories {
-        mavenLocal()
-        // ... other repositories
+  repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+  repositories {
+    google()
+    mavenCentral()
+    maven {
+      url = uri("https://maven.pkg.github.com/synonymdev/bitkit-core")
+      credentials {
+          username = System.getenv("GITHUB_ACTOR") ?: providers.gradleProperty("gpr.user").orNull
+          password = System.getenv("GITHUB_TOKEN") ?: providers.gradleProperty("gpr.key").orNull
+      }
     }
+  }
+}
+```
+
+#### 3. Declare the dependency
+
+```kotlin
+// app/build.gradle.kts
+dependencies {
+  implementation("com.synonym:bitkit-core-android:<VERSION>")
+  // example:
+  // implementation("com.synonym:bitkit-core-android:0.1.0")
+}
+```
+### Maven Local (development)
+
+```kotlin
+// settings.gradle.kts
+dependencyResolutionManagement {
+  repositories {
+    mavenLocal()
+    // others
+  }
 }
 
-// build.gradle.kts  
+// build.gradle.kts
 dependencies {
-    implementation("com.synonym:bitkit-core-android:LATEST_VERSION")
+  implementation("com.synonym:bitkit-core-android:<LOCAL_VERSION>")
 }
+```
+
+---
+
+## Publishing
+
+**⚠️ Reminder:** Versions are immutable, bump for each publish.
+
+### GitHub Actions
+
+Create a GitHub Release with a new tag like `v0.1.0`. The workflow `gradle-publish.yml` will publish that version.
+
+### Terminal
+
+```sh
+cd bindings/android
+./gradlew publish -Pversion=0.1.0
 ```

--- a/bindings/android/build.gradle.kts
+++ b/bindings/android/build.gradle.kts
@@ -8,8 +8,5 @@ buildscript {
     }
 }
 
-// library version is defined in gradle.properties
-val libraryVersion: String by project
-
-group = "com.synonym"
-version = libraryVersion
+group = providers.gradleProperty("group").orNull ?: "com.synonym"
+version = providers.gradleProperty("version").orNull ?: "0.0.0"

--- a/bindings/android/gradle.properties
+++ b/bindings/android/gradle.properties
@@ -2,4 +2,5 @@ org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official
-libraryVersion=0.1.9
+group=com.synonym
+version=0.1.9

--- a/bindings/android/lib/build.gradle.kts
+++ b/bindings/android/lib/build.gradle.kts
@@ -1,6 +1,3 @@
-// library version is defined in gradle.properties
-val libraryVersion: String by project
-
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android") version "1.9.10"
@@ -68,16 +65,15 @@ afterEvaluate {
     publishing {
         publications {
             create<MavenPublication>("maven") {
-                groupId = "com.synonym"
-                artifactId = "bitkit-core-android"
-                version = libraryVersion
+                val mavenArtifactId = "bitkit-core-android"
+                groupId = providers.gradleProperty("group").orNull ?: "com.synonym"
+                artifactId = mavenArtifactId
+                version = providers.gradleProperty("version").orNull ?: "0.0.0"
 
                 from(components["release"])
                 pom {
-                    name.set("bitkit-core-android")
-                    description.set(
-                        "Bitkit Core Android bindings library."
-                    )
+                    name.set(mavenArtifactId)
+                    description.set("Bitkit Core Android bindings.")
                     url.set("https://github.com/synonymdev/bitkit-core")
                     licenses {
                         license {
@@ -92,6 +88,19 @@ afterEvaluate {
                             email.set("noreply@synonym.to")
                         }
                     }
+                }
+            }
+        }
+        repositories {
+            maven {
+                val repo = System.getenv("GITHUB_REPO")
+                    ?: providers.gradleProperty("gpr.repo").orNull
+                    ?: "synonymdev/bitkit-core"
+                name = "GitHubPackages"
+                url = uri("https://maven.pkg.github.com/$repo")
+                credentials {
+                    username = System.getenv("GITHUB_ACTOR") ?: providers.gradleProperty("gpr.user").orNull
+                    password = System.getenv("GITHUB_TOKEN") ?: providers.gradleProperty("gpr.key").orNull
                 }
             }
         }

--- a/build_android.sh
+++ b/build_android.sh
@@ -152,7 +152,7 @@ fi
 # Sync version
 echo "Syncing version from Cargo.toml..."
 CARGO_VERSION=$(grep '^version = ' Cargo.toml | sed 's/version = "\(.*\)"/\1/' | head -1)
-sed -i.bak "s/^libraryVersion=.*/libraryVersion=$CARGO_VERSION/" "$ANDROID_LIB_DIR/gradle.properties"
+sed -i.bak "s/^version=.*/version=$CARGO_VERSION/" "$ANDROID_LIB_DIR/gradle.properties"
 rm -f "$ANDROID_LIB_DIR/gradle.properties.bak"
 
 # Verify android library publish

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,3 +1,0 @@
-jdk: openjdk17
-before_install:
-  - cd bindings/android


### PR DESCRIPTION
This PR:
- setups distribution for android via github packages
- adds gradle-publish workflow
- removes jitpack setup

Tested via bitkit-android PR:
- https://github.com/synonymdev/bitkit-android/pull/294