### PR TITLE
ci: fix Android package publish token

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.event.release.tag_name }}
     - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
@@ -51,6 +53,6 @@ jobs:
       working-directory: bindings/android
       env:
         GITHUB_ACTOR: ${{ github.actor }}
-        GITHUB_TOKEN: ${{ secrets.ORG_PACKAGES_TOKEN }}
+        GITHUB_TOKEN: ${{ github.token }}
         GITHUB_REPO: ${{ github.repository }}
       run: ./gradlew publish -Pversion=${{ steps.version.outputs.version }}


### PR DESCRIPTION
## Summary
- publish the Android package with the repo GitHub token, which already has packages: write permission
- checkout the requested tag when manually dispatching the publish workflow

## Context
The v0.1.63 Android publish run built successfully but failed to upload to GitHub Packages with 401 Unauthorized using ORG_PACKAGES_TOKEN. This leaves com.synonym:bitkit-core-android:0.1.63 unavailable to the Android app.